### PR TITLE
Fix/s3 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to semantic versioning.
 ### Removed
 
 
+## [3.0.1] - 2022-10-07
+
+### Added
+- AWS_DEFAULT_REGION environment variable
+
+### Changed
+- boto3 connection uses virtual adressing
+
 ## [3.0.0] - 2022-04-11
 
 Initial public release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocs-thumbnail-service"
-version = "2.2.0"
+version = "3.0.1"
 description = "This is a flask application that generates thumbnails from data stored in an OCS Science Archive."
 authors = ["Observatory Control System Project <ocs@lco.global>"]
 homepage = "https://observatorycontrolsystem.github.io"

--- a/thumbservice/common.py
+++ b/thumbservice/common.py
@@ -16,6 +16,7 @@ class Settings:
         self.AWS_BUCKET = self.set_value('AWS_BUCKET', 'changeme')
         self.AWS_ACCESS_KEY_ID = self.set_value('AWS_ACCESS_KEY_ID', 'changeme')
         self.AWS_SECRET_ACCESS_KEY = self.set_value('AWS_SECRET_ACCESS_KEY', 'changeme')
+        self.AWS_DEFAULT_REGION = self.set_value('AWS_DEFAULT_REGION', 'us-west-2')
         self.STORAGE_URL = self.set_value('STORAGE_URL', None)
         self.REQUIRED_FRAME_VALIDATION_KEYS = self.get_tuple_from_environment('REQUIRED_FRAME_VALIDATION_KEYS', 'configuration_type,request_id,filename')
         self.VALID_CONFIGURATION_TYPES = self.get_tuple_from_environment('VALID_CONFIGURATION_TYPES', 'ARC,BIAS,BPM,DARK,DOUBLE,EXPERIMENTAL,EXPOSE,GUIDE,LAMPFLAT,SKYFLAT,SPECTRUM,STANDARD,TARGET,TRAILED')

--- a/thumbservice/thumbservice.py
+++ b/thumbservice/thumbservice.py
@@ -120,7 +120,7 @@ def convert_to_jpg(paths, key, **params):
 
 
 def get_s3_client():
-    config = boto3.session.Config(region_name='us-west-2', signature_version='s3v4')
+    config = boto3.session.Config(region_name=settings.AWS_DEFAULT_REGION, signature_version='s3v4', s3={'addressing_style': 'virtual'})
     return boto3.client(
         's3',
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
These were the changes required to make it work with minio in the ocs_example project. They also bring its usage of the boto3 client in line with the ocs_archive project. I believe this should work fine on S3 since we use the same settings in the ocs_archive, but we should check on dev just to make sure I guess.