### PR TITLE
Narrow band and colour images

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Both endpoints take the following query parameters:
 * height
 * label
 * image
+* color (true|false)
+* planet (true|false)
 
 Width and height are in pixels, label will appear as white text in the lower left had corner of the image.
 

--- a/thumbservice/tests.py
+++ b/thumbservice/tests.py
@@ -7,6 +7,8 @@ import boto3
 import pytest
 import requests
 from moto import mock_s3
+import numpy as np
+from PIL import Image
 
 from thumbservice import common
 from thumbservice import thumbservice
@@ -189,6 +191,22 @@ def mock_fits_to_jpeg():
     m = thumbservice.fits_to_jpg = mock.MagicMock()
     m.side_effect = side_effect
 
+
+@pytest.fixture()
+def mock_planet_image_to_jpg():
+    def side_effect(*args, **kwargs):
+        Path(args[1]).touch()
+    m = thumbservice.planet_image_to_jpg = mock.MagicMock()
+    m.side_effect = side_effect
+
+
+@pytest.fixture()
+def mock_planet_image_data():
+    def side_effect(*args, **kwargs):
+        return np.zeros((9, 9))
+
+    m = common.planet_image_data = mock.MagicMock()
+    m.side_effect = side_effect
 
 def make_tmp_file(tmp_path, filename, suffix):
     path = tmp_path / Path(filename).with_suffix(suffix)
@@ -479,3 +497,102 @@ def test_frame_basename_does_not_exist(thumbservice_client, requests_mock, tmp_p
     response = thumbservice_client.get('/some_frame_that_doesnt_exist/')
     assert response.status_code == 404
     assert len(list(tmp_path.glob('*'))) == 0
+
+def test_planet_color(thumbservice_client, requests_mock, s3_client, tmp_path,mock_planet_image_to_jpg):
+    frame = deepcopy(_test_data['frame'])
+    request_frames = deepcopy(_test_data['request_frames'])
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(f'{TEST_API_URL}frames/?request_id={frame["request_id"]}&reduction_level=91', json=request_frames)
+    for request_frame in request_frames['results']:
+        requests_mock.get(request_frame['url'], content=b'I Am Image')
+    response1 = thumbservice_client.get(f'/{frame["id"]}/?planet=true&color=true')
+    call_count_after_1 = requests_mock.call_count
+    response2 = thumbservice_client.get(f'/{frame["id"]}/?planet=true&color=true')
+    call_count_after_2 = requests_mock.call_count
+    for response in [response1, response2]:
+        response_as_json = response.get_json()
+        assert response_as_json['propid'] == frame['proposal_id']
+        assert 'url' in response_as_json
+        assert response.status_code == 200
+    # The resource will have been created in s3 on the first call, on the second call less work needs to
+    # be done, including only 1 call to requests as opposed to the 5 on initial creation
+    assert call_count_after_1 == 5
+    assert call_count_after_2 == 6
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+def test_planet_black_and_white(thumbservice_client, requests_mock, s3_client, tmp_path, mock_planet_image_to_jpg):
+    frame = deepcopy(_test_data['frame'])
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(frame['url'], content=b'I Am Image')
+    response1 = thumbservice_client.get(f'/{frame["id"]}/?planet=true')
+    call_count_after_1 = requests_mock.call_count
+    response2 = thumbservice_client.get(f'/{frame["id"]}/?planet=true')
+    call_count_after_2 = requests_mock.call_count
+    for response in [response1, response2]:
+        response_as_json = response.get_json()
+        assert response_as_json['propid'] == frame['proposal_id']
+        assert 'url' in response_as_json
+        assert response.status_code == 200
+    # The resource will have been created in s3 on the first call, on the second call less work needs to
+    # be done, including only 1 call to requests as opposed to the 2 on initial creation
+    assert call_count_after_1 == 2
+    assert call_count_after_2 == 3
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+def test_one_filter_for_planet_color_thumbnail_not_available(thumbservice_client, requests_mock, s3_client, tmp_path, mock_planet_image_to_jpg):
+    frame = deepcopy(_test_data['frame'])
+    request_frames = deepcopy(_test_data['request_frames'])
+    request_frames['results'][2]['primary_optical_element'] = 'H-Alpha'
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(f'{TEST_API_URL}frames/?request_id={frame["request_id"]}&reduction_level=91', json=request_frames)
+    response = thumbservice_client.get(f'/{frame["id"]}/?color=true&planet=true')
+    assert response.status_code == 404
+    assert b'Wrong combination of RVB frames' in response.data
+    assert len(list(tmp_path.glob('*'))) == 0
+
+def test_planet_color_narrow_band(thumbservice_client, requests_mock, s3_client, tmp_path, mock_planet_image_to_jpg):
+    frame = deepcopy(_test_data['narrow_frame'])
+    request_frames = deepcopy(_test_data['narrow_request_frames'])
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(f'{TEST_API_URL}frames/?request_id={frame["request_id"]}&reduction_level=91', json=request_frames)
+    for request_frame in request_frames['results']:
+        requests_mock.get(request_frame['url'], content=b'I Am Image')
+    response1 = thumbservice_client.get(f'/{frame["id"]}/?planet=true&color=true')
+    call_count_after_1 = requests_mock.call_count
+    response2 = thumbservice_client.get(f'/{frame["id"]}/?planet=true&color=true')
+    call_count_after_2 = requests_mock.call_count
+    for response in [response1, response2]:
+        response_as_json = response.get_json()
+        assert response_as_json['propid'] == frame['proposal_id']
+        assert 'url' in response_as_json
+        assert response.status_code == 200
+    # The resource will have been created in s3 on the first call, on the second call less work needs to
+    # be done, including only 1 call to requests as opposed to the 5 on initial creation
+    assert call_count_after_1 == 5
+    assert call_count_after_2 == 6
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+def test_planet_image_to_jpg_3_files(mock_planet_image_data, tmp_path):
+    filenames = ['file1.fits', 'file2.fits', 'file3.fits']
+    common.planet_image_to_jpg(filenames, tmp_path / 'test.jpg')
+
+    imagefiles = list(tmp_path.glob('*'))
+    assert len(imagefiles) == 1
+    assert imagefiles[0].name == 'test.jpg'
+    # Test we have a RGB image
+    img = Image.open(imagefiles[0])
+    assert img.mode == 'RGB'
+
+def test_planet_image_to_jpg_1_file(mock_planet_image_data, tmp_path):
+    filenames = ['file1.fits',]
+    common.planet_image_to_jpg(filenames, tmp_path / 'test.jpg')
+
+    imagefiles = list(tmp_path.glob('*'))
+    assert len(imagefiles) == 1
+    assert imagefiles[0].name == 'test.jpg'
+    # Test we have a greyscale image
+    img = Image.open(imagefiles[0])
+    assert img.mode == 'L'

--- a/thumbservice/thumbservice.py
+++ b/thumbservice/thumbservice.py
@@ -172,19 +172,29 @@ def frames_for_requestnum(request_id, request, reduction_level):
 
 
 def rvb_frames(frames):
-    FILTERS_FOR_COLORS = {
-        'red': ['R', 'rp'],
-        'visual': ['V'],
-        'blue': ['B'],
+    FILTERS = {
+        'red': ['r', 'rp','ip','h-alpha'],
+        'visual': ['v','oiii'],
+        'blue': ['b','gp','sii'],
     }
+    NARROW = ['h-alpha','oiii','sii']
+
     selected_frames = []
+    narrow_check = []
     for color in ['red', 'visual', 'blue']:
         try:
             selected_frames.append(
-                next(f for f in frames if f['primary_optical_element'] in FILTERS_FOR_COLORS[color])
+            next(f for f in frames if f['primary_optical_element'].lower() in FILTERS[color])
             )
         except StopIteration:
             raise ThumbnailAppException('RVB frames not found', status_code=404)
+
+    narrow_check = [f['primary_optical_element'].lower() for f in selected_frames if f['primary_optical_element'].lower() in NARROW]
+    if len(narrow_check) == 3 and (sorted(narrow_check) == NARROW):
+        pass
+    elif len(narrow_check) != 0:
+        raise ThumbnailAppException('Wrong combination of RVB frames', status_code=404)
+    
     return selected_frames
 
 

--- a/thumbservice/thumbservice.py
+++ b/thumbservice/thumbservice.py
@@ -124,9 +124,9 @@ def convert_to_jpg(paths, key, **params):
     fits_to_jpg(paths, jpg_path, **params)
     return jpg_path
 
-def convert_to_planet_jpg(paths, key):
+def convert_to_planet_jpg(paths, key, **params):
     jpg_path = f'{unique_temp_path_start()}{key}'
-    planet_image_to_jpg(paths, jpg_path)
+    planet_image_to_jpg(paths, jpg_path, **params)
     return jpg_path
 
 def get_s3_client():
@@ -273,7 +273,7 @@ def generate_thumbnail(frame, request):
         if not params['planet']:
             jpg_path = convert_to_jpg(paths.paths, key, **params)
         else:
-            jpg_path = convert_to_planet_jpg(paths.paths, key)
+            jpg_path = convert_to_planet_jpg(paths.paths, key, **params)
         upload_to_s3(key, jpg_path)
     finally:
         # Cleanup actions


### PR DESCRIPTION
I've updated the colour composite framework to include the narrowband filters for making colour images.

I've also added a planet option. This is different to the rest of the thumbnail code in that it always generates images of the same size 600 x 600 centred around a planet. The aim is to provide more reasonable scaling for planets which mostly lose their features when using `fits_to_jpg`. It also balances the colours better in a colour image.

I've added extra test coverage.

I will update the portal code to check for planets on the request (probably using the `scheme==JPL_MAJOR_PLANET`)